### PR TITLE
♻️ 카카오 소셜 로그인 자체 JWT 적용

### DIFF
--- a/src/main/java/CodeIt/Ytrip/auth/dto/request/RegisterRequest.java
+++ b/src/main/java/CodeIt/Ytrip/auth/dto/request/RegisterRequest.java
@@ -5,7 +5,6 @@ import lombok.Data;
 @Data
 public class RegisterRequest {
 
-    String username;
     String nickname;
     String email;
     String password;

--- a/src/main/java/CodeIt/Ytrip/common/JwtUtils.java
+++ b/src/main/java/CodeIt/Ytrip/common/JwtUtils.java
@@ -23,17 +23,17 @@ public class JwtUtils {
     @Value("${JWT.SECRET.KEY}")
     private String key;
 
-    public String generateToken(Long userId, int expireTime, String tokenName) {
+    public String generateToken(String email, int expireTime, String tokenName) {
         return Jwts.builder()
-                .claims(createClaims(userId))
+                .claims(createClaims(email))
                 .expiration(createExpireDate(expireTime))
                 .signWith(createSigningKey())
                 .compact();
     }
 
-    private Map<String, Object> createClaims(Long userId) {
+    private Map<String, Object> createClaims(String email) {
         Map<String, Object> claims = new HashMap<>();
-        claims.put("userId", userId);
+        claims.put("email", email);
         return claims;
     }
 

--- a/src/main/java/CodeIt/Ytrip/common/exception/ApiExceptionHandler.java
+++ b/src/main/java/CodeIt/Ytrip/common/exception/ApiExceptionHandler.java
@@ -32,5 +32,11 @@ public class ApiExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.of(e.getStatus(), e.getMessage()));
     }
 
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<?> RunTimeExceptionHandler(RuntimeException e) {
+        log.error("Token Exception = {}, {}", e.getMessage(), e.getStatus());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ErrorResponse.of(e.getStatus(), e.getMessage()));
+    }
+
 
 }

--- a/src/main/java/CodeIt/Ytrip/common/exception/RuntimeException.java
+++ b/src/main/java/CodeIt/Ytrip/common/exception/RuntimeException.java
@@ -1,0 +1,32 @@
+package CodeIt.Ytrip.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class RuntimeException extends java.lang.RuntimeException {
+    private String status;
+    public RuntimeException() {
+        super();
+    }
+
+    public RuntimeException(StatusCode statusCode) {
+        super(statusCode.getMessage());
+        this.status = statusCode.getCode();
+    }
+
+    public RuntimeException(String message) {
+        super(message);
+    }
+
+    public RuntimeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RuntimeException(Throwable cause) {
+        super(cause);
+    }
+
+    protected RuntimeException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/CodeIt/Ytrip/common/exception/StatusCode.java
+++ b/src/main/java/CodeIt/Ytrip/common/exception/StatusCode.java
@@ -13,7 +13,8 @@ public enum StatusCode {
     DUPLICATE_EMAIL("4002", "중복된 이메일입니다."),
     USER_NOT_FOUND("4003", "존재하지 않는 유저 입니다."),
     TOKEN_IS_NULL("4004", "토큰이 없습니다."),
-    TOKEN_IS_TAMPERED("4005", "토큰이 위조되었습니다.");
+    TOKEN_IS_TAMPERED("4005", "토큰이 위조되었습니다."),
+    INTERNAL_SERVER_ERROR("5000", "일시적인 오류입니다. 잠시후 다시 시도해 주세요.");
 
     private final String code;
     private final String message;

--- a/src/main/java/CodeIt/Ytrip/common/interceptor/JwtInterceptor.java
+++ b/src/main/java/CodeIt/Ytrip/common/interceptor/JwtInterceptor.java
@@ -19,6 +19,7 @@ public class JwtInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        System.out.println("request.getRequestURI() = " + request.getRequestURI());
         String token = jwtUtils.splitBearerToken(request.getHeader("Authorization"));
         if (jwtUtils.isValidToken(token)) {
             log.info("AccessToken = {}", token);

--- a/src/main/java/CodeIt/Ytrip/user/domain/User.java
+++ b/src/main/java/CodeIt/Ytrip/user/domain/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import lombok.Builder;
 import lombok.Getter;
 
 @Entity
@@ -13,7 +14,6 @@ public class User {
     @Id @GeneratedValue
     @Column(name = "user_id")
     private Long id;
-    private String username;
     private String nickname;
     private String email;
     private String password;
@@ -21,8 +21,7 @@ public class User {
 
     public User() {}
 
-    public void createUser(String username, String nickname, String email, String password, String refreshToken) {
-        this.username = username;
+    public void createUser(String nickname, String email, String password, String refreshToken) {
         this.nickname = nickname;
         this.email = email;
         this.password = password;

--- a/src/main/java/CodeIt/Ytrip/user/repository/UserRepository.java
+++ b/src/main/java/CodeIt/Ytrip/user/repository/UserRepository.java
@@ -15,4 +15,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByRefreshToken(String refreshToken);
 
+    Optional<User> findByEmail(String email);
+
 }


### PR DESCRIPTION
## 1. 작업이유
- 이전에 생성했던 로컬 JWT를 카카오 소셜로그인에 적용
- 로컬 로그인시 유저 존재 여부와 상관없이 모든 필드가 update되는 문제 해결

## 2. 작업사항
### 1. 작업 예정
- 네이버 소셜 로그인에 JWT 적용

### 2. 에러 사항
- 없음