### PR TITLE
 ♻️ 네이버 소셜 로그인 자체 JWT 적용

### DIFF
--- a/src/main/java/CodeIt/Ytrip/auth/controller/AuthController.java
+++ b/src/main/java/CodeIt/Ytrip/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package CodeIt.Ytrip.auth.controller;
 import CodeIt.Ytrip.auth.dto.request.LocalLoginRequest;
 import CodeIt.Ytrip.auth.dto.request.RegisterRequest;
 import CodeIt.Ytrip.auth.service.AuthService;
+import CodeIt.Ytrip.auth.service.SocialService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -17,10 +18,11 @@ import java.util.Map;
 public class AuthController {
 
     private final AuthService authService;
+    private final SocialService socialService;
     @PostMapping("/kakao/login")
     public ResponseEntity<?> kakaoLogin(@RequestBody Map<String, String> request) {
         String code = request.get("code");
-        return authService.kakaoLogin(code);
+        return socialService.kakaoLogin(code);
     }
 
     @PostMapping("/register")
@@ -48,6 +50,6 @@ public class AuthController {
     @PostMapping ("/naver/login")
     public ResponseEntity<?> naverLogin(@RequestBody Map<String, String> request) {
         String code = request.get("code");
-        return authService.naverLogin(code);
+        return socialService.naverLogin(code);
     }
 }

--- a/src/main/java/CodeIt/Ytrip/auth/service/AuthService.java
+++ b/src/main/java/CodeIt/Ytrip/auth/service/AuthService.java
@@ -6,7 +6,7 @@ import CodeIt.Ytrip.auth.dto.KakaoUserInfoDto;
 import CodeIt.Ytrip.auth.dto.request.LocalLoginRequest;
 import CodeIt.Ytrip.auth.dto.request.RegisterRequest;
 import CodeIt.Ytrip.common.exception.RuntimeException;
-import CodeIt.Ytrip.common.exception.StatusCode;
+import CodeIt.Ytrip.common.reponse.StatusCode;
 import CodeIt.Ytrip.common.exception.UserException;
 import CodeIt.Ytrip.common.JwtUtils;
 import CodeIt.Ytrip.common.reponse.SuccessResponse;

--- a/src/main/java/CodeIt/Ytrip/auth/service/AuthService.java
+++ b/src/main/java/CodeIt/Ytrip/auth/service/AuthService.java
@@ -1,11 +1,8 @@
 package CodeIt.Ytrip.auth.service;
 
-import CodeIt.Ytrip.auth.dto.NaverUserInfoDto;
 import CodeIt.Ytrip.auth.dto.TokenDto;
-import CodeIt.Ytrip.auth.dto.KakaoUserInfoDto;
 import CodeIt.Ytrip.auth.dto.request.LocalLoginRequest;
 import CodeIt.Ytrip.auth.dto.request.RegisterRequest;
-import CodeIt.Ytrip.common.exception.RuntimeException;
 import CodeIt.Ytrip.common.reponse.StatusCode;
 import CodeIt.Ytrip.common.exception.UserException;
 import CodeIt.Ytrip.common.JwtUtils;
@@ -14,16 +11,10 @@ import CodeIt.Ytrip.user.domain.User;
 import CodeIt.Ytrip.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestTemplate;
 
 import java.util.Optional;
 
@@ -33,108 +24,8 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class AuthService {
 
-    @Value("${KAKAO.REDIRECT.URI}")
-    private String redirectUri;
-    @Value("${KAKAO.REST.API.KEY}")
-    private String restAPiKey;
-    @Value("${NAVER.CLIENT.ID}")
-    private String naverClientId;
-    @Value("${NAVER.CLIENT.SECRET}")
-    private String naverClientSecret;
-    @Value("${NAVER.REDIRECT.URI}")
-    private String naverRedirectUri;
     private final JwtUtils jwtUtils;
-
     private final UserRepository userRepository;
-
-    public ResponseEntity<?> kakaoLogin(String code) {
-        KakaoUserInfoDto kakaoUserInfo = getAccessToken(code);
-        User user = new User();
-        Optional<User> findUser = userRepository.findByEmail(kakaoUserInfo.getEmail());
-        if (findUser.isPresent()) {
-           user.updateRefreshToken(kakaoUserInfo.getRefreshToken());
-        } else {
-            user.createUser(
-                    kakaoUserInfo.getNickName(),
-                    kakaoUserInfo.getEmail(),
-                    null,
-                    kakaoUserInfo.getRefreshToken()
-            );
-        }
-        userRepository.save(user);
-        return ResponseEntity.ok(SuccessResponse.of(StatusCode.SUCCESS.getCode(), StatusCode.SUCCESS.getMessage(), kakaoUserInfo));
-    }
-
-    private KakaoUserInfoDto getAccessToken(String code) {
-        log.info("code = {}", code);
-
-        try {
-            HttpHeaders headers = new HttpHeaders();
-            headers.add(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded;charset=utf-8");
-
-            MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-            body.add("grant_type", "authorization_code");
-            body.add("client_id", restAPiKey);
-            body.add("redirect_uri", redirectUri);
-            body.add("code", code);
-
-            HttpEntity<MultiValueMap<String, String>> kakaoRequest = new HttpEntity<>(body, headers);
-            log.info("KAKAO REQUEST = {}", kakaoRequest);
-            RestTemplate restTemplate = new RestTemplate();
-            ResponseEntity<String> kakaoToken = restTemplate.exchange(
-                    "https://kauth.kakao.com/oauth/token",
-                    HttpMethod.POST,
-                    kakaoRequest,
-                    String.class
-            );
-            System.out.println("kakaoToken = " + kakaoToken.getBody());
-            log.info("KAKAO TOKEN ={}", kakaoToken);
-
-            JSONParser jsonParser = new JSONParser();
-            JSONObject jsonObject = (JSONObject) jsonParser.parse(kakaoToken.getBody());
-
-            TokenDto tokenDto = new TokenDto(
-                    (String) jsonObject.get("access_token"),
-                    (String) jsonObject.get("refresh_token"));
-
-            return getKakaoUserInfo(tokenDto);
-
-        } catch (ParseException e) {
-            throw new RuntimeException(StatusCode.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-
-    private KakaoUserInfoDto getKakaoUserInfo(TokenDto tokenDto) throws ParseException {
-        log.info("KAKAO TOKEN DTO = {}", tokenDto);
-        HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(tokenDto.getAccessToken());
-        headers.setContentType(MediaType.valueOf("application/x-www-form-urlencoded;charset=utf-8"));
-        HttpEntity body = new HttpEntity(null, headers);
-
-        log.info("Get Kakao User Info API Http Body = {}", body);
-        RestTemplate restTemplate = new RestTemplate();
-
-        ResponseEntity<String> kakaoUser = restTemplate.exchange(
-                "https://kapi.kakao.com/v2/user/me",
-                HttpMethod.POST,
-                body,
-                String.class
-        );
-        log.info("KAKAO USER = {}", kakaoUser);
-
-        JSONParser jsonParser = new JSONParser();
-        JSONObject jsonObject = (JSONObject) jsonParser.parse(kakaoUser.getBody());
-        JSONObject kakaoAccount = (JSONObject) jsonObject.get("kakao_account");
-        JSONObject profile = (JSONObject) kakaoAccount.get("profile");
-        String nickname = String.valueOf(profile.get("nickname"));
-        String email = String.valueOf(kakaoAccount.get("email"));
-        String accessToken = jwtUtils.generateToken(email, 1000 * 60 * 60, "AccessToken");
-        String refreshToken = jwtUtils.generateToken(email, 1000 * 60 * 60 * 24, "RefreshToken");
-        log.info("Nickname = {}, email = {}, accessToken = {}, refreshToken = {}", nickname, email, accessToken, refreshToken);
-
-        return new KakaoUserInfoDto(nickname, email, accessToken, refreshToken);
-    }
 
     public ResponseEntity<?> register(RegisterRequest registerRequest) {
 
@@ -182,92 +73,5 @@ public class AuthService {
             }
         }
         throw new UserException(StatusCode.LOGIN_REQUIRED);
-    }
-
-    public ResponseEntity<?> naverLogin(String code) {
-        NaverUserInfoDto naverUserInfo = getNAccessToken(code);
-
-        User user = new User();
-        user.createUser(
-                naverUserInfo.getNickName(),
-                naverUserInfo.getEmail(),
-                null,
-                naverUserInfo.getRefreshToken()
-        );
-
-        userRepository.save(user);
-        return ResponseEntity.ok(SuccessResponse.of(StatusCode.SUCCESS.getCode(), StatusCode.SUCCESS.getMessage(), naverUserInfo));
-    }
-
-    private NaverUserInfoDto getNAccessToken(String code) {
-        log.info("NAVER code = {}", code);
-        try {
-            HttpHeaders headers = new HttpHeaders();
-            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-            params.add("grant_type", "authorization_code");
-            params.add("client_id", naverClientId); // 네이버 클라이언트 ID를 설정 파일에서 불러와야 합니다.
-            params.add("client_secret", naverClientSecret); // 네이버 클라이언트 시크릿을 설정 파일에서 불러와야 합니다.
-            params.add("redirect_uri", naverRedirectUri); // 네이버 리다이렉트 URI를 설정 파일에서 불러와야 합니다.
-            params.add("code", code);
-
-            HttpEntity<MultiValueMap<String, String>> naverRequest = new HttpEntity<>(params, headers);
-            log.info("NAVER REQUEST = {}", naverRequest);
-            RestTemplate restTemplate = new RestTemplate();
-            ResponseEntity<String> naverTokenResponse = restTemplate.exchange(
-                    "https://nid.naver.com/oauth2.0/token",
-                    HttpMethod.POST,
-                    naverRequest,
-                    String.class
-            );
-
-            log.info("NAVER TOKEN = {}", naverTokenResponse.getBody());
-
-            JSONParser jsonParser = new JSONParser();
-            JSONObject jsonObject = (JSONObject) jsonParser.parse(naverTokenResponse.getBody());
-
-            TokenDto tokenDto = new TokenDto(
-                    (String) jsonObject.get("access_token"),
-                    (String) jsonObject.get("refresh_token"));
-
-            return getNaverUserInfo(tokenDto);
-
-        } catch (ParseException e) {
-            log.error(e.getMessage());
-        }
-
-        return null;
-    }
-    private NaverUserInfoDto getNaverUserInfo(TokenDto tokenDto) throws ParseException {
-        // 로직의 대부분은 유지되지만, NaverUserInfoDto 생성 부분을 수정해야 합니다.
-        log.info("NAVER TOKEN DTO = {}", tokenDto);
-        HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(tokenDto.getAccessToken());
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        HttpEntity<?> body = new HttpEntity<>(headers);
-
-        RestTemplate restTemplate = new RestTemplate();
-        ResponseEntity<String> naverUserResponse = restTemplate.exchange(
-                "https://openapi.naver.com/v1/nid/me",
-                HttpMethod.POST,
-                body,
-                String.class
-        );
-
-        log.info("NAVER USER = {}", naverUserResponse.getBody());
-
-        JSONParser jsonParser = new JSONParser();
-        JSONObject jsonObject = (JSONObject) jsonParser.parse(naverUserResponse.getBody());
-        JSONObject response = (JSONObject) jsonObject.get("response");
-
-        String nickname = (String) response.get("nickname");
-        String email = (String) response.get("email");
-        String accessToken = tokenDto.getAccessToken();
-        String refreshToken = tokenDto.getRefreshToken();
-
-        log.info("Nickname = {}, email = {}, accessToken = {}, refreshToken = {}", nickname, email, accessToken, refreshToken);
-
-        return new NaverUserInfoDto(nickname, email, accessToken, refreshToken);
     }
 }

--- a/src/main/java/CodeIt/Ytrip/auth/service/SocialService.java
+++ b/src/main/java/CodeIt/Ytrip/auth/service/SocialService.java
@@ -1,0 +1,223 @@
+package CodeIt.Ytrip.auth.service;
+
+import CodeIt.Ytrip.auth.dto.NaverUserInfoDto;
+import CodeIt.Ytrip.auth.dto.TokenDto;
+import CodeIt.Ytrip.auth.dto.KakaoUserInfoDto;
+import CodeIt.Ytrip.common.exception.RuntimeException;
+import CodeIt.Ytrip.common.reponse.StatusCode;
+import CodeIt.Ytrip.common.JwtUtils;
+import CodeIt.Ytrip.common.reponse.SuccessResponse;
+import CodeIt.Ytrip.user.domain.User;
+import CodeIt.Ytrip.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+
+@Slf4j
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class SocialService {
+
+    @Value("${KAKAO.REDIRECT.URI}")
+    private String redirectUri;
+    @Value("${KAKAO.REST.API.KEY}")
+    private String restAPiKey;
+    @Value("${NAVER.CLIENT.ID}")
+    private String naverClientId;
+    @Value("${NAVER.CLIENT.SECRET}")
+    private String naverClientSecret;
+    @Value("${NAVER.REDIRECT.URI}")
+    private String naverRedirectUri;
+    private final JwtUtils jwtUtils;
+
+    private final UserRepository userRepository;
+
+    public ResponseEntity<?> kakaoLogin(String code) {
+        KakaoUserInfoDto kakaoUserInfo = getKakaoAccessToken(code);
+        User user = new User();
+        Optional<User> findUser = userRepository.findByEmail(kakaoUserInfo.getEmail());
+        if (findUser.isPresent()) {
+            user.updateRefreshToken(kakaoUserInfo.getRefreshToken());
+        } else {
+            user.createUser(
+                    kakaoUserInfo.getNickName(),
+                    kakaoUserInfo.getEmail(),
+                    null,
+                    kakaoUserInfo.getRefreshToken()
+            );
+        }
+        userRepository.save(user);
+        return ResponseEntity.ok(SuccessResponse.of(StatusCode.SUCCESS.getCode(), StatusCode.SUCCESS.getMessage(), kakaoUserInfo));
+    }
+
+    private KakaoUserInfoDto getKakaoAccessToken(String code) {
+        log.info("code = {}", code);
+
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.add(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded;charset=utf-8");
+
+            MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+            body.add("grant_type", "authorization_code");
+            body.add("client_id", restAPiKey);
+            body.add("redirect_uri", redirectUri);
+            body.add("code", code);
+
+            HttpEntity<MultiValueMap<String, String>> kakaoRequest = new HttpEntity<>(body, headers);
+            log.info("KAKAO REQUEST = {}", kakaoRequest);
+            RestTemplate restTemplate = new RestTemplate();
+            ResponseEntity<String> kakaoToken = restTemplate.exchange(
+                    "https://kauth.kakao.com/oauth/token",
+                    HttpMethod.POST,
+                    kakaoRequest,
+                    String.class
+            );
+            System.out.println("kakaoToken = " + kakaoToken.getBody());
+            log.info("KAKAO TOKEN ={}", kakaoToken);
+
+            JSONParser jsonParser = new JSONParser();
+            JSONObject jsonObject = (JSONObject) jsonParser.parse(kakaoToken.getBody());
+
+            TokenDto tokenDto = new TokenDto(
+                    (String) jsonObject.get("access_token"),
+                    (String) jsonObject.get("refresh_token"));
+
+            return getKakaoUserInfo(tokenDto);
+
+        } catch (ParseException e) {
+            throw new RuntimeException(StatusCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+
+    private KakaoUserInfoDto getKakaoUserInfo(TokenDto tokenDto) throws ParseException {
+        log.info("KAKAO TOKEN DTO = {}", tokenDto);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(tokenDto.getAccessToken());
+        headers.setContentType(MediaType.valueOf("application/x-www-form-urlencoded;charset=utf-8"));
+        HttpEntity body = new HttpEntity(null, headers);
+
+        log.info("Get Kakao User Info API Http Body = {}", body);
+        RestTemplate restTemplate = new RestTemplate();
+
+        ResponseEntity<String> kakaoUser = restTemplate.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.POST,
+                body,
+                String.class
+        );
+        log.info("KAKAO USER = {}", kakaoUser);
+
+        JSONParser jsonParser = new JSONParser();
+        JSONObject jsonObject = (JSONObject) jsonParser.parse(kakaoUser.getBody());
+        JSONObject kakaoAccount = (JSONObject) jsonObject.get("kakao_account");
+        JSONObject profile = (JSONObject) kakaoAccount.get("profile");
+        String nickname = String.valueOf(profile.get("nickname"));
+        String email = String.valueOf(kakaoAccount.get("email"));
+        String accessToken = jwtUtils.generateToken(email, 1000 * 60 * 60, "AccessToken");
+        String refreshToken = jwtUtils.generateToken(email, 1000 * 60 * 60 * 24, "RefreshToken");
+        log.info("Nickname = {}, email = {}, accessToken = {}, refreshToken = {}", nickname, email, accessToken, refreshToken);
+
+        return new KakaoUserInfoDto(nickname, email, accessToken, refreshToken);
+    }
+
+    public ResponseEntity<?> naverLogin(String code) {
+        NaverUserInfoDto naverUserInfo = getNaverAccessToken(code);
+        User user = new User();
+        Optional<User> findUser = userRepository.findByEmail(naverUserInfo.getEmail());
+        if (findUser.isPresent()) {
+            user.updateRefreshToken(user.getRefreshToken());
+        } else {
+            user.createUser(
+                    naverUserInfo.getNickName(),
+                    naverUserInfo.getEmail(),
+                    null,
+                    naverUserInfo.getRefreshToken()
+            );
+        }
+        userRepository.save(user);
+        return ResponseEntity.ok(SuccessResponse.of(StatusCode.SUCCESS.getCode(), StatusCode.SUCCESS.getMessage(), naverUserInfo));
+    }
+
+    private NaverUserInfoDto getNaverAccessToken(String code) {
+        log.info("NAVER code = {}", code);
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add("grant_type", "authorization_code");
+            params.add("client_id", naverClientId); // 네이버 클라이언트 ID를 설정 파일에서 불러와야 합니다.
+            params.add("client_secret", naverClientSecret); // 네이버 클라이언트 시크릿을 설정 파일에서 불러와야 합니다.
+            params.add("redirect_uri", naverRedirectUri); // 네이버 리다이렉트 URI를 설정 파일에서 불러와야 합니다.
+            params.add("code", code);
+
+            HttpEntity<MultiValueMap<String, String>> naverRequest = new HttpEntity<>(params, headers);
+            log.info("NAVER REQUEST = {}", naverRequest);
+            RestTemplate restTemplate = new RestTemplate();
+            ResponseEntity<String> naverTokenResponse = restTemplate.exchange(
+                    "https://nid.naver.com/oauth2.0/token",
+                    HttpMethod.POST,
+                    naverRequest,
+                    String.class
+            );
+
+            log.info("NAVER TOKEN = {}", naverTokenResponse.getBody());
+
+            JSONParser jsonParser = new JSONParser();
+            JSONObject jsonObject = (JSONObject) jsonParser.parse(naverTokenResponse.getBody());
+
+            TokenDto tokenDto = new TokenDto(
+                    (String) jsonObject.get("access_token"),
+                    (String) jsonObject.get("refresh_token"));
+
+            return getNaverUserInfo(tokenDto);
+
+        } catch (ParseException e) {
+            throw new RuntimeException(StatusCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+    private NaverUserInfoDto getNaverUserInfo(TokenDto tokenDto) throws ParseException {
+        // 로직의 대부분은 유지되지만, NaverUserInfoDto 생성 부분을 수정해야 합니다.
+        log.info("NAVER TOKEN DTO = {}", tokenDto);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(tokenDto.getAccessToken());
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        HttpEntity<?> body = new HttpEntity<>(headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> naverUserResponse = restTemplate.exchange(
+                "https://openapi.naver.com/v1/nid/me",
+                HttpMethod.POST,
+                body,
+                String.class
+        );
+
+        log.info("NAVER USER = {}", naverUserResponse.getBody());
+
+        JSONParser jsonParser = new JSONParser();
+        JSONObject jsonObject = (JSONObject) jsonParser.parse(naverUserResponse.getBody());
+        JSONObject response = (JSONObject) jsonObject.get("response");
+
+        String nickname = (String) response.get("nickname");
+        String email = (String) response.get("email");
+        String accessToken = jwtUtils.generateToken(email, 1000 * 60 * 60, "AccessToken");
+        String refreshToken = jwtUtils.generateToken(email, 1000 * 60 * 60 * 24, "RefreshToken");
+
+        log.info("Nickname = {}, email = {}, accessToken = {}, refreshToken = {}", nickname, email, accessToken, refreshToken);
+
+        return new NaverUserInfoDto(nickname, email, accessToken, refreshToken);
+    }
+}

--- a/src/main/java/CodeIt/Ytrip/common/JwtUtils.java
+++ b/src/main/java/CodeIt/Ytrip/common/JwtUtils.java
@@ -1,6 +1,6 @@
 package CodeIt.Ytrip.common;
 
-import CodeIt.Ytrip.common.exception.StatusCode;
+import CodeIt.Ytrip.common.reponse.StatusCode;
 import CodeIt.Ytrip.common.exception.TokenException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;

--- a/src/main/java/CodeIt/Ytrip/common/exception/RuntimeException.java
+++ b/src/main/java/CodeIt/Ytrip/common/exception/RuntimeException.java
@@ -1,5 +1,6 @@
 package CodeIt.Ytrip.common.exception;
 
+import CodeIt.Ytrip.common.reponse.StatusCode;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/CodeIt/Ytrip/common/exception/TokenException.java
+++ b/src/main/java/CodeIt/Ytrip/common/exception/TokenException.java
@@ -1,5 +1,6 @@
 package CodeIt.Ytrip.common.exception;
 
+import CodeIt.Ytrip.common.reponse.StatusCode;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/CodeIt/Ytrip/common/exception/UserException.java
+++ b/src/main/java/CodeIt/Ytrip/common/exception/UserException.java
@@ -1,5 +1,6 @@
 package CodeIt.Ytrip.common.exception;
 
+import CodeIt.Ytrip.common.reponse.StatusCode;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/CodeIt/Ytrip/common/exception/handler/ApiExceptionHandler.java
+++ b/src/main/java/CodeIt/Ytrip/common/exception/handler/ApiExceptionHandler.java
@@ -1,5 +1,9 @@
-package CodeIt.Ytrip.common.exception;
+package CodeIt.Ytrip.common.exception.handler;
 
+import CodeIt.Ytrip.common.exception.RuntimeException;
+import CodeIt.Ytrip.common.reponse.StatusCode;
+import CodeIt.Ytrip.common.exception.TokenException;
+import CodeIt.Ytrip.common.exception.UserException;
 import CodeIt.Ytrip.common.reponse.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/CodeIt/Ytrip/common/interceptor/JwtInterceptor.java
+++ b/src/main/java/CodeIt/Ytrip/common/interceptor/JwtInterceptor.java
@@ -1,7 +1,7 @@
 package CodeIt.Ytrip.common.interceptor;
 
 import CodeIt.Ytrip.common.JwtUtils;
-import CodeIt.Ytrip.common.exception.StatusCode;
+import CodeIt.Ytrip.common.reponse.StatusCode;
 import CodeIt.Ytrip.common.exception.UserException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/CodeIt/Ytrip/common/reponse/StatusCode.java
+++ b/src/main/java/CodeIt/Ytrip/common/reponse/StatusCode.java
@@ -1,4 +1,4 @@
-package CodeIt.Ytrip.common.exception;
+package CodeIt.Ytrip.common.reponse;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/CodeIt/Ytrip/common/reponse/CommonApiResponseTest.java
+++ b/src/test/java/CodeIt/Ytrip/common/reponse/CommonApiResponseTest.java
@@ -1,6 +1,5 @@
 package CodeIt.Ytrip.common.reponse;
 
-import CodeIt.Ytrip.common.exception.StatusCode;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
 

--- a/src/test/java/CodeIt/Ytrip/controller/TestController.java
+++ b/src/test/java/CodeIt/Ytrip/controller/TestController.java
@@ -1,8 +1,7 @@
 package CodeIt.Ytrip.controller;
 
-import CodeIt.Ytrip.common.exception.StatusCode;
+import CodeIt.Ytrip.common.reponse.StatusCode;
 import CodeIt.Ytrip.common.exception.UserException;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;


### PR DESCRIPTION
## 1. 작업 이유
- 이전에 생성했던 로컬 JWT를 네이버 소셜로그인에 적용
- 네이버 로그인시 유저 존재 여부와 상관없이 모든 필드가 update되는 문제 해결
- `ResponseEntity`를 통한 상태 코드 지정
- 글로벌 예외 처리
