### PR TITLE
🐛 WebConfig를 통한 CORS 문제 해결

### DIFF
--- a/src/main/java/CodeIt/Ytrip/auth/controller/AuthController.java
+++ b/src/main/java/CodeIt/Ytrip/auth/controller/AuthController.java
@@ -14,7 +14,6 @@ import java.util.Map;
 @Slf4j
 @RestController
 @RequestMapping("/api/auth")
-@CrossOrigin
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/src/main/java/CodeIt/Ytrip/auth/controller/AuthController.java
+++ b/src/main/java/CodeIt/Ytrip/auth/controller/AuthController.java
@@ -14,7 +14,7 @@ import java.util.Map;
 @Slf4j
 @RestController
 @RequestMapping("/api/auth")
-@CrossOrigin(origins = "*")
+@CrossOrigin
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/src/main/java/CodeIt/Ytrip/auth/controller/AuthController.java
+++ b/src/main/java/CodeIt/Ytrip/auth/controller/AuthController.java
@@ -14,6 +14,7 @@ import java.util.Map;
 @Slf4j
 @RestController
 @RequestMapping("/api/auth")
+@CrossOrigin(origins = "*")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/src/main/java/CodeIt/Ytrip/config/WebConfig.java
+++ b/src/main/java/CodeIt/Ytrip/config/WebConfig.java
@@ -3,6 +3,7 @@ package CodeIt.Ytrip.config;
 import CodeIt.Ytrip.common.interceptor.JwtInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -22,5 +23,21 @@ public class WebConfig implements WebMvcConfigurer {
 //                .addPathPatterns("/**")
 //                .excludePathPatterns("/api/auth/**","/test/**");
 //    }
+
+    /**
+     * CORS 설정
+     * 현재 모든 리소스의 요청을 허용
+     * 추후 프론트 서버만 요청 허용하도록 변경 필요
+     */
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE")
+                .allowedHeaders("Authorization", "Content-Type")
+                .exposedHeaders("Custom-Header")
+//                .allowCredentials(true)
+                .maxAge(3600);
+    }
 }
 

--- a/src/main/java/CodeIt/Ytrip/video/controller/VideoController.java
+++ b/src/main/java/CodeIt/Ytrip/video/controller/VideoController.java
@@ -5,16 +5,14 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@CrossOrigin(origins = "*")
 @RequestMapping("/api/video")
 public class VideoController {
 

--- a/src/main/java/CodeIt/Ytrip/video/controller/VideoController.java
+++ b/src/main/java/CodeIt/Ytrip/video/controller/VideoController.java
@@ -12,7 +12,6 @@ import java.util.List;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@CrossOrigin(origins = "*")
 @RequestMapping("/api/video")
 public class VideoController {
 


### PR DESCRIPTION
## 1. 작업 내용:
- CORS 문제 해결

## 2. 작업 사항
### 1. 관련 이슈 
- #37 (해결)
  - Custom Filter를 등록하지 않고 `WebMvcConfigurer`에서 제공하는 `addCorsMappings` 사용

```
public void addCorsMappings(CorsRegistry registry) {
        registry.addMapping("/**")
                .allowedOrigins("*")
                .allowedMethods("GET", "POST", "PUT", "DELETE")
                .allowedHeaders("Authorization", "Content-Type")
                .exposedHeaders("Custom-Header")
//                .allowCredentials(true)
                .maxAge(3600);
    }
```
현재 모든 외부 리소스에 대한 상호작용을 허용하고 있습니다. 이 경우 보안상의 문제가 존재할 수 있기 때문에 수정이 필요할 것 입니다.
또한 allowCredentials 설정의 경우 모든 외부 리소스를 허용하면 사용할 수 없기에 주석처리 하였습니다. 추후 프론트 서버의 도메인만 상호작용을 허용한다면 Credentials 설정을 진행할 수 있을 것으로 기대됩니다.

### 2. 에러 사항
- 없음